### PR TITLE
Fix link to second abstraction-comprehension post

### DIFF
--- a/_posts/2018/11/2018-11-03-abstraction-comprehension.md
+++ b/_posts/2018/11/2018-11-03-abstraction-comprehension.md
@@ -84,4 +84,4 @@ so for now I'll focus on ways to clearly identify who lessons are for
 and to make sure that we're teaching everyone at their most comfortable level of abstraction
 rather than our own.
 
-**Later:** see also [the next post in this series]({{site.github.url}}/2018/11/05/abstraction-comprehension.html).
+**Later:** see also [the next post in this series]({{site.github.url}}/2018/11/03/abstraction-comprehension-continued.html).


### PR DESCRIPTION
Despite the file names, for some reason the second in the series also seems to be indexed under `11/03` http://third-bit.com/2018/11/03/abstraction-comprehension-continued.html