### PR TITLE
fix Ark documentation link

### DIFF
--- a/src/colophon.md
+++ b/src/colophon.md
@@ -5,7 +5,7 @@ template: page
 
 This site's name comes from the saying that data is ones and zeroes,
 but software is ones and zeroes and hard work.
-It is built using [Ark](https://www.dmulholl.com/docs/ark/main/),
+It is built using [Ark](https://www.dmulholl.com/docs/ark/master/),
 formatted with [Chota](https://jenil.github.io/chota/),
 and checked with [WAVE](https://wave.webaim.org/),
 [html5validator](https://github.com/svenkreiss/html5validator),


### PR DESCRIPTION
Fix the hyperlink for Ark in the [colophon page](https://third-bit.com/colophon/). Updates it to point to the correct master docs link. :)

_P.S. I was also wondering whether the [link checker](https://linkchecker.github.io/linkchecker/) mentioned in the same sentence in set up?_